### PR TITLE
Add standard size options

### DIFF
--- a/cups-img.drv
+++ b/cups-img.drv
@@ -3,7 +3,40 @@
 
 Font *
 
+// Configured print sizes below
+// * prefix for MediaSize marks default option
+
+#media "5x5.Fullbleed/5x5" 5in 5in
+MediaSize 5x5.Fullbleed
 #media "4x6.Fullbleed/6x4" 4in 6in
+*MediaSize 4x6.Fullbleed
+#media "6x6.Fullbleed/6x6" 6in 6in
+MediaSize 6x6.Fullbleed
+#media "5x7.Fullbleed/7x5" 5in 7in
+MediaSize 5x7.Fullbleed
+#media "6x8.Fullbleed/8x6" 6in 8in
+MediaSize 6x8.Fullbleed
+#media "8x8.Fullbleed/8x8" 8in 8in
+MediaSize 8x8.Fullbleed
+#media "8x10.Fullbleed/10x8" 8in 10in
+MediaSize 8x10.Fullbleed
+#media "10x10.Fullbleed/10x10" 10in 10in
+MediaSize 10x10.Fullbleed
+#media "8x12.Fullbleed/12x8" 8in 12in
+MediaSize 8x12.Fullbleed
+#media "10x12.Fullbleed/12x10" 10in 12in
+MediaSize 10x12.Fullbleed
+#media "12x12.Fullbleed/12x12" 12in 12in
+MediaSize 12x12.Fullbleed
+#media "12x18.Fullbleed/12x18" 12in 18in
+MediaSize 12x18.Fullbleed
+#media "18x24.Fullbleed/18x24" 18in 24in
+MediaSize 18x24.Fullbleed
+#media "24x36.Fullbleed/24x36" 24in 36in
+MediaSize 24x36.Fullbleed
+#media "20x30.Fullbleed/20x30" 20in 30in
+MediaSize 20x30.Fullbleed
+
 DriverType custom
 
 Manufacturer LiveLink
@@ -12,8 +45,6 @@ Version 1.0
 Filter image/jpeg 100 imgcap-raw
 Filter image/png 100 imgcap-raw
 Filter application/pdf 100 imgcap-raw
-
-*MediaSize 4x6.Fullbleed
 
 {
   ModelName "Image Capture"

--- a/cups-img.drv
+++ b/cups-img.drv
@@ -28,12 +28,6 @@ MediaSize 8x12.Fullbleed
 MediaSize 10x12.Fullbleed
 #media "12x12.Fullbleed/12x12" 12in 12in
 MediaSize 12x12.Fullbleed
-#media "12x18.Fullbleed/12x18" 12in 18in
-MediaSize 12x18.Fullbleed
-#media "18x24.Fullbleed/18x24" 18in 24in
-MediaSize 18x24.Fullbleed
-#media "24x36.Fullbleed/24x36" 24in 36in
-MediaSize 24x36.Fullbleed
 #media "20x30.Fullbleed/20x30" 20in 30in
 MediaSize 20x30.Fullbleed
 


### PR DESCRIPTION
Ref issue #1, this allows users on modern iOS versions to have greater choice over the size of the transmitted image. 6x4 is still the default so older iOS versions that don't allow paper size choice may still come through in an undesired resolution

A few sizes were added then removed, as in the iOS AirPrint dialog they showed as:
"Arch B" instead of 12x18
"Arch C" instead of 18x14
"Arch D" instead of 24x36 

Which was undesirable at the time